### PR TITLE
Added docker development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
 venv
+.bash_history
+.viminfo
+.v/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+from centos:latest
+
+RUN yum -y update
+
+RUN yum -y install ruby\
+                   rubygems\
+                   vim\
+                   screen
+
+EXPOSE 80
+EXPOSE 8000
+EXPOSE 22
+
+WORKDIR "/root"
+
+CMD "/bin/echo 'Please Specify a Command when you docker run'"

--- a/dockersetup.sh
+++ b/dockersetup.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+###
+# Compiles a docker container for development of IAM.
+###
+# WARNING:
+#   This script mounts the current working directory to /root in the container.
+#   Don't do anything stupid like `rm -rf /` in the container.
+###
+
+IMAGE='iam/dev'
+
+# Help is requested.
+if [[ $@ == '-h' || $@ == '--help' ]];
+then
+    echo "dockersetup.sh: Develop IAM in docker"
+    echo
+    echo "USAGE:"
+    echo "dockersetup.sh [-b|--build] [-h|--help]"
+    echo
+    echo "-h | --help   : Prints his help menu"
+    echo "-b | --build  : Does a full docker build"
+
+# A build is requested.
+elif [[ $@ == '-b' || $@ == '--build' ]];
+then
+    echo "This might take a while."
+    echo "Feel free to grab a cup of coffee."
+
+    # We run centos in production
+    docker pull centos:latest
+
+    # Build the container and tag it IAM/dev
+    if [[ -f "Dockerfile" ]];
+    then
+        docker build -t $IMAGE .
+    else
+        echo "Missing the Dockerfile"
+        exit 1
+    fi
+
+# Running the container is requested.
+else
+    docker images | grep iam
+
+    if [[ $? == 1 ]];
+    then
+        echo "Run 'dockersetup.sh -b' first"
+    else
+        # The `rm -rf ...` at the end is due to a weird permissions error when
+        # building. Comment out the end of the line if you need your history.
+        docker run -it -v $PWD:/root $IMAGE $SHELL && rm -rf .bash_history .viminfo
+    fi
+fi


### PR DESCRIPTION
Run the script `dockersetup.sh -b` to build the environment.
Run the script alone to start and enter a dev container.
Run the script with the `-h` or `--help` flag for help.
Add packages to the Dockerfile when you need them installed.

Re-build when necessary.

This should help make development easier. I could be wrong.

@matthewrsj @Kennric Thoughts?

> Spoiler, it's just a bash script that wraps around some docker commands.