### PR TITLE
Add rufus scheduler for collect ganeti

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dockerfiles/app
 dockerfiles/app.env
 docker-compose.yml
 *.db
+dump.rdb

--- a/scheduler.rb
+++ b/scheduler.rb
@@ -3,12 +3,10 @@ require_relative 'collectors'
 
 s = Rufus::Scheduler.new
 
-p [ :scheduled_at, Time.now ]
-
 s.every '30m', :first_in => 0.4 do
-    collector = Collectors.new
-    collector.collect_ganeti
-    p [ :success,  Time.now ]
+  # Collect ganeti node information every 30 minutes
+  collector = Collectors.new
+  collector.collect_ganeti
 end
 
 s.join

--- a/scheduler.rb
+++ b/scheduler.rb
@@ -1,0 +1,14 @@
+require 'rufus/scheduler'
+require_relative 'collectors'
+
+s = Rufus::Scheduler.new
+
+p [ :scheduled_at, Time.now ]
+
+s.every '30m', :first_in => 0.4 do
+    collector = Collectors.new
+    collector.collect_ganeti
+    p [ :success,  Time.now ]
+end
+
+s.join


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #28, sort of. This just runs the collect_ganeti method because there is no plugin collect method to run yet.

## Changes in this PR.
<!--
  Please include a lsit of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Add rufus scheduler that runs Collectors.collect_ganeti method every 30 minutes

## Testing this PR.
<!--
  Please include a lsit of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Install redis (unless you can use docker)
2. run the `redis-server` binary in different terminal
3. run `ruby scheduler.rb` in a different terminal
4. run the `redis-cli` binary, type `keys *` --> you should get output

@osuosl/devs

