### PR TITLE
Add plugin specs to rake spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,8 +33,19 @@ task :rubocop do
   end
 end
 
-RSpec::Core::RakeTask.new(:spec) do |t|
-    ENV["RACK_ENV"] = "test"
-    t.pattern = Dir.glob('spec/**/*_spec.rb')
-    t.rspec_opts = '--format documentation'
+# rake spec
+task spec: [:specs, :spec_plugins] do
+end
+
+# spec files in the spec/ folder
+RSpec::Core::RakeTask.new(:specs) do |t|
+  ENV['RACK_ENV'] = 'test'
+  t.pattern = Dir.glob('spec/**/*_spec.rb')
+  t.rspec_opts = '--format documentation'
+end
+
+# spec files in the plugins folders
+RSpec::Core::RakeTask.new(:spec_plugins) do |t|
+  t.pattern = Dir.glob('plugins/**/*spec.rb')
+  t.rspec_opts = '--format documentation'
 end


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
* Make `rake spec` run both app tests and plugin tests.
* I couldn't figure out how to make one RakeTask object take two different directories so I created two of them and had `rake spec` run both as a workaround

## Changes in this PR.
<!--
  Please include a lsit of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Changed `rake spec` to take plugin spec files

## Testing this PR.
<!--
  Please include a lsit of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Start docker container: `$ docker-compose run dev bash`
2. `rake spec`
3. See app spec and plugin spec files run

Expected output:
```
[root@c54637efcc44 code]# rake spec
/usr/local/bin/ruby -I/usr/local/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib:/usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib /usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec spec/models/client_spec.rb --format documentation

The Client Model and table
  can create a client
  has no clients
  has a name

Finished in 0.00727 seconds (files took 0.64559 seconds to load)
3 examples, 0 failures

/usr/local/bin/ruby -I/usr/local/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib:/usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib /usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec --format documentation

The Client Model and table
  can create a client
  has no clients
  has a name

Finished in 0.0077 seconds (files took 0.63401 seconds to load)
3 examples, 0 failures

```


