### PR TITLE
Rake spec should only use one rspec run

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,18 +34,9 @@ task :rubocop do
 end
 
 # rake spec
-task spec: [:specs, :spec_plugins] do
-end
-
-# spec files in the spec/ folder
-RSpec::Core::RakeTask.new(:specs) do |t|
+RSpec::Core::RakeTask.new(:spec) do |t|
   ENV['RACK_ENV'] = 'test'
-  t.pattern = Dir.glob('spec/**/*_spec.rb')
+  t.pattern = Dir.glob('{spec,plugins}/**/*spec.rb')
   t.rspec_opts = '--format documentation'
 end
 
-# spec files in the plugins folders
-RSpec::Core::RakeTask.new(:spec_plugins) do |t|
-  t.pattern = Dir.glob('plugins/**/*spec.rb')
-  t.rspec_opts = '--format documentation'
-end


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #60 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] `rake spec` runs all spec tests in one run

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. `docker-compose run dev bash`
2. `rake spec`

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
[root@c499ce58a036 code]# rake spec
/usr/local/bin/ruby -I/usr/local/lib/ruby/gems/2.3.0/gems/rspec-support-3.4.1/lib:/usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/lib /usr/local/lib/ruby/gems/2.3.0/gems/rspec-core-3.4.4/exe/rspec plugins/disk_sizes/spec.rb spec/models/client_spec.rb spec/routes/app_spec.rb spec/routes/client_spec.rb --format documentation

DiskSize
  .register does not raise an error when invoked
  .register actually actually creates a disk_size_measurements table
  .store does not fail with valid data
  .store fails when not passed node name
undefined method `tr' for nil:NilClass
  .store does not crash when passed improperly formatted data
  .store properly sums all disk sizes when storing in DB
  .report method
    should return data on all nodes for the last day by default
    returns data on a known specific nodes for 1 day
    returns empty on unknown node
    should return empty on invalid day input
    should return empty on invalid fqdn input

The Client Model and table
  initially has no clients
  has a model name
  can create a client
  cannot create two clients with the same name
  can create two clients with different names
  cannot create a client without required fields
  cannot create a client without required fields
  can delete a client
  can update a client
  cannot update a client to have a non-unique name

The IAM Application
  says hello

The Client list endpoint
"Client X"
  responds OK
"Client X"
  contains the name of a client we added

Finished in 0.07318 seconds (files took 0.31841 seconds to load)
24 examples, 0 failures
```

@osuosl/devs

