### PR TITLE
Update Scheduler Store Task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,7 @@ end
 
 # rake plugins
 task :plugins do
+  puts 'Registering plugins'
   # Get name of each plugin from folder name.
   # At this point, we are assuming the plugin is *not* registered and is
   # therefore not in the plugins table.

--- a/Rakefile
+++ b/Rakefile
@@ -50,9 +50,7 @@ task :plugins do
     # The actual name is the last part of the filename (plugin/<name>).
     plugin_name = File.split(name)[-1]
     # Require each plugin and register.
-    Dir["#{name}/plugin.rb"].each do |plugin|
-      require plugin
-      Object.const_get(plugin_name).new
-    end
+    require "#{name}/plugin.rb"
+    Object.const_get(plugin_name).new
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -40,3 +40,18 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = '--format documentation'
 end
 
+# rake plugins
+task :plugins do
+  # Get name of each plugin from folder name.
+  # At this point, we are assuming the plugin is *not* registered and is
+  # therefore not in the plugins table.
+  Dir['plugins/*'].each do |name|
+    # The actual name is the last part of the filename (plugin/<name>).
+    plugin_name = File.split(name)[-1]
+    # Require each plugin and register.
+    Dir["#{name}/plugin.rb"].each do |plugin|
+      require plugin
+      Object.const_get(plugin_name).new
+    end
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -46,9 +46,9 @@ task :plugins do
   # Get name of each plugin from folder name. Require each plugin and register.
   # At this point, we are assuming the plugin is *not* registered and is
   # therefore not in the plugins table.
-  Dir['plugins/*'].each do |name|
-    require "#{name}/plugin.rb"
-    # The actual name is the last part of the filename (plugin/<name>).
-    Object.const_get(File.split(name)[-1]).new
+  Dir['plugins/*/plugin.rb'].each do |name|
+    require name
+    # The actual name is the middle part of the path (plugin/<name>/plugin.rb).
+    Object.const_get(name.split('/')[1]).new
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -43,14 +43,12 @@ end
 # rake plugins
 task :plugins do
   puts 'Registering plugins'
-  # Get name of each plugin from folder name.
+  # Get name of each plugin from folder name. Require each plugin and register.
   # At this point, we are assuming the plugin is *not* registered and is
   # therefore not in the plugins table.
   Dir['plugins/*'].each do |name|
-    # The actual name is the last part of the filename (plugin/<name>).
-    plugin_name = File.split(name)[-1]
-    # Require each plugin and register.
     require "#{name}/plugin.rb"
-    Object.const_get(plugin_name).new
+    # The actual name is the last part of the filename (plugin/<name>).
+    Object.const_get(File.split(name)[-1]).new
   end
 end

--- a/plugins/DiskSize/plugin.rb
+++ b/plugins/DiskSize/plugin.rb
@@ -62,6 +62,4 @@ class DiskSize
     # format and make json/csv thing
     dataset.all.to_json
   end
-
 end
-

--- a/plugins/VCPUCount/spec.rb
+++ b/plugins/VCPUCount/spec.rb
@@ -78,7 +78,7 @@ describe 'VCPUCount plugin' do
   # Report method
   describe '.report method' do
     before(:all) do
-      VCPUCount.new    # Make sure initialize is called
+      VCPUCount.new # Make sure initialize is called
       @db_table.insert(created: Time.now,
                        node:    'goodnode',
                        value:   8)

--- a/scheduler.rb
+++ b/scheduler.rb
@@ -3,6 +3,7 @@ require 'redis'
 require_relative 'collectors'
 require_relative 'plugins/disk_sizes/plugin.rb'
 
+redis = Redis.new(host: ENV['REDIS_HOST'])
 s = Rufus::Scheduler.new
 
 s.every '30m', first_in: 0.4 do
@@ -13,11 +14,20 @@ end
 
 # Change '15m' on next line to 4 to test
 s.every '30m', first_in: 4 do
-  redis = Redis.new(host: ENV['REDIS_HOST'])
-  DiskSize.new.register
-  redis.keys.each do |key|
-    DiskSize.new.store key unless key.end_with?(':datetime')
+  Iam.settings.DB[:plugins].get(:name).each do |plugin|
+    puts plugin
+    require_relative "plugins/#{plugin}/plugin.rb"
+    redis.keys.each do |key|
+      Object.const_get(plugin).store key unless key.end_with?(':datetime')
+    end
   end
 end
+
+
+#  DiskSize.new.register
+#  redis.keys.each do |key|
+#    DiskSize.new.store key unless key.end_with?(':datetime')
+#  end
+#end
 
 s.join

--- a/scheduler.rb
+++ b/scheduler.rb
@@ -14,6 +14,7 @@ end
 
 # Change '15m' on next line to 4 to test
 s.every '30m', first_in: '15m' do
+  `rake plugins`
   # For each entry in the plugins table
   Iam.settings.DB[:plugins].each do |p|
     # Require the plugin based on the name in the table


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes #67 

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

#### Rakefile:
- [X] Create `plugins` task to register plugins with `rake`
  - [X] Load/require plugins by name from plugin folder names
  - [X] Register each plugin

#### Scheduler:
- [X] Call `rake plugins`
- [X] Load/require plugins by name from plugins table
- [X] Call store method on each plugin

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. `docker-compose run dev bash`
2. `rake spec` - Not really necessary for these changes, but just make sure nothing fails.
3. `rake migrate`
4. In `scheduler.rb`: change `'15m'` on line 16 to `4` (note, no quotes `'`) and add `puts 'done'` before the last `end` on line 29.
5. `ruby scheduler.rb` and wait for `done` to print, then press CTRL-C
6. `sqlite3 /tmp/development.sqlite`
7. `select * from disk_size_measurements;`
8. `select * from vcpu_count_measurements;`

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ rake spec
[... passing tests ...]
$ rake migrate
Migrating to latest
$ ruby scheduler.rb
[... a lot of time passing ...]
done
$ sqlite3 /tmp/development.sqlite
SQLite version 3.7.17 2013-05-20 00:56:22
Enter ".help" for instructions
Enter SQL statements terminated with a ";"
sqlite> select * from disk_size_measurements;
[... 180+ rows of disk size measurements ...]
sqlite> select * from vcpu_count_measurements;
[... 180+ rows of vcpu count measurements ...]
```
@osuosl/devs
