### PR TITLE
Minor changes before the deploy.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,13 @@
 # require 'sequel'
 require 'rake'
 require 'rspec/core/rake_task'
-require File.expand_path '../environment.rb', __FILE__
+require_relative 'environment'
 
 task default: [:run]
 
 task run: [:migrate] do
   ruby 'app.rb'
+  ruby 'scheduler.rb'
 end
 
 task :migrate, [:version] do |t, args|

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,5 @@
 require 'sinatra/base'
-require_relative 'environment.rb'
+require_relative 'environment'
 
 # IAM - a resource usage metric collection and reporting system
 class Iam < Sinatra::Base
@@ -10,69 +10,10 @@ class Iam < Sinatra::Base
   (Dir['plugins/*/plugin.rb'] + Dir['routes/*.rb']).each do |file|
     require file
   end
+
   register Sinatra::MainRoutes
   register Sinatra::ClientRoutes
   register Sinatra::ProjectRoutes
 
-  ##
-  # Projects
-  ##
-
-  get '/projects/new' do
-    # get new project form
-    erb :'projects/edit'
-  end
-
-  get '/projects/:id' do
-    # view a project
-    @project = Project[id: params[:id]]
-    halt 404, 'Project not found' if @project.nil?
-    erb :'projects/show'
-  end
-
-  get '/projects/:id/edit' do
-    # get project edit form
-    @project = Project[id: params[:id]]
-    halt 404, 'Project not found' if @project.nil?
-    erb :'projects/edit'
-  end
-
-  get '/projects' do
-    # get a list of all projects
-    @projects = Project.each { |x| p x.name }
-    erb :'projects/index'
-  end
-
-  # This could also be PUT
-  post '/projects' do
-    # recieve new project
-    project = Project.create(name:        params[:name],
-                             client_id:   Iam.settings.DB[:clients]
-                                            .where(name: params[:client_name])
-                                            .get(:id) || '',
-                             resources:   params[:resources] || '',
-                             description: params[:description] || '')
-    redirect "/projects/#{project.id}"
-  end
-
-  patch '/projects' do
-    # recieve an updated project
-    project = Project[id: params[:id]]
-    project.update(name:        params[:name] || project.name,
-                   client_id:   Iam.settings.DB[:clients]
-                                  .where(name: params[:client_name])
-                                  .get(:id) || project.client_id,
-                   resources:   params[:resources] || project.resources,
-                   description: params[:description] || project.description)
-    redirect "/projects/#{params[:id]}"
-  end
-
-  delete '/projects/:id' do
-    # delete a project
-    @project = Project[id: params[:id]]
-    @project.delete unless @project.nil?
-    redirect '/projects' unless @project.nil?
-    404
-  end
-
+  run! unless ENV['RACK_ENV'] == 'test'
 end

--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -51,6 +51,10 @@ class Cache
     end
   end
 
+  def keys
+    return @hash.keys
+  end
+
   def __ensure_path
     directory = File.dirname(@path)
     FileUtils.mkdir_p(directory) unless File.directory?(directory)


### PR DESCRIPTION
## Changes

- Run `ruby app.rb` and `ruby scheduler.rb` with `rake` command.
- When you run `rake` it should automatically start the app and the collector.
- Added `keys` method to cache. Otherwise `scheduler.rb` breaks.

## Testing

```
$ rake spec
[... Tests still pass ...]
```
The testing procedure for PR #68 is also a pretty good way to check this for validity. Run `rake` instead of `ruby scheduler.rb`.
```
[root@c6d98b33fa8a code]# rake
Migrating to latest
/usr/local/bin/ruby app.rb
== Sinatra (v1.4.7) has taken the stage on 4567 for development with backup from Thin
Thin web server (v1.7.0 codename Dunder Mifflin)
Maximum connections set to 1024
Listening on localhost:4567, CTRL+C to stop
```

Refs #83 I guess.

@osuosl/devs @Kennric 