### PR TITLE
Refactored disk_size plugin model to take array of values

### DIFF
--- a/plugins/DiskSize/migrations/001_migrations.rb
+++ b/plugins/DiskSize/migrations/001_migrations.rb
@@ -8,7 +8,10 @@ Sequel.migration do
       foreign_key   :node_resource
       Time          :created, null: false
       String        :node
-      Integer       :value
+      Integer       :disk_count
+      Integer       :disk1_size, default: 0
+      Integer       :disk2_size, default: 0
+      Integer       :disk3_size, default: 0
       Boolean       :active
     end
   end

--- a/plugins/DiskSize/plugin.rb
+++ b/plugins/DiskSize/plugin.rb
@@ -26,14 +26,20 @@ class DiskSize < BasePlugin
       raise "No disk_sizes information for #{fqdn}"
     end
 
+    # prep data for DB insert
+    # get array length and data formatted
+    count = node_info['disk_sizes'].split.length
+    values = node_info['disk_sizes'].tr('[]', '')    # remove '[' and ']'
+                                    .split(',')      # split into array
+                                    .map(&:to_i)     # convert to integer
+
     # Insert data into disk_size_measurements table
     @@database[@@table].insert(
       node:          fqdn,
-      value:         node_info['disk_sizes']
-                       .tr('[]', '')    # remove '[' and ']' from string
-                       .split(',')      # split into array of strings on ','
-                       .map(&:to_i)     # convert each element to integer
-                       .inject(0, :+),  # inject a + method to sum the array
+      disk_count:    count,
+      disk1_size:    values[0] || 0,
+      disk2_size:    values[1] || 0,
+      disk3_size:    values[2] || 0,
       active:        node_info['active'],
       created:       DateTime.now,
       node_resource: @@database[:node_resources].where(name: fqdn).get(:id))

--- a/plugins/DiskSize/spec.rb
+++ b/plugins/DiskSize/spec.rb
@@ -12,8 +12,8 @@ describe 'DiskSize plugin' do
     end
 
     before(:each) do
-      @cache.set('goodnode', disk_sizes: '[10,20]', active: true)
-      @cache.set('badnode', disk_size: '[10,20]', active: true)
+      @cache.set('goodnode', disk_sizes: '[10, 20]', active: true)
+      @cache.set('badnode', disk_size: '[10, 20]', active: true)
       @cache.write
     end
 
@@ -47,12 +47,14 @@ describe 'DiskSize plugin' do
       expect { @db_table.where(node: 'goodnode').to exist }
     end
 
-    it 'properly sums all disk sizes when storing in DB' do
+    it 'properly stores all disk sizes when storing in DB' do
       # Store node data
       DiskSize.new.store('goodnode')
 
       # Make sure store method properly summed disk sizes
-      expect(@db_table.where(node: 'goodnode').get(:value)).to eq(30)
+      expect(@db_table.where(node: 'goodnode').get(:disk_count)).to eq(2)
+      expect(@db_table.where(node: 'goodnode').get(:disk1_size)).to eq(10)
+      expect(@db_table.where(node: 'goodnode').get(:disk2_size)).to eq(20)
     end
   end
 end


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #81, should allow us to have finer detail on disk_sizes in the future. The only caveat is that max disk count is currently at 3. We can change in the future if we find a need more than that.

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] Refactored the disk_size plugin's data model
- [X] Updated disk_size's tests for the new data model

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Start IAM in docker
2. `rake spec`

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ rake spec
...

DiskSize plugin
  .store method
    does not fail with valid data
    fails when not passed node name
No disk_sizes information for badnode: {"disk_size"=>"[10, 20]", "active"=>true}
    does not crash when passed improperly formatted data
    properly stores all disk sizes when storing in DB
...
Finished in 0.26475 seconds (files took 0.74526 seconds to load)
88 examples, 0 failures
```

@Kennric @subnomo @athai @ElijahCaine