### PR TITLE
removed default node and db resources and fixed plugin/spec for them

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -16,13 +16,9 @@ class Iam < Sinatra::Base
   # to make sure every record is collected into the hierarchy
   default_client = Client.find_or_create(name: 'default',
                                          description: 'The default client')
-  default_project = Project.find_or_create(name: 'default',
-                                           client_id: default_client.id,
-                                           description: 'The default project')
-  NodeResource.find_or_create(project_id: default_project.id,
-                              name: 'default')
-  DBResource.find_or_create(project_id: default_project.id,
-                            name: 'default')
+  Project.find_or_create(name: 'default',
+                         client_id: default_client.id,
+                         description: 'The default project')
 
   register Sinatra::MainRoutes
   register Sinatra::ClientRoutes

--- a/lib/BasePlugin/plugin.rb
+++ b/lib/BasePlugin/plugin.rb
@@ -69,16 +69,18 @@ class BasePlugin
   # already. Assign it to the default project.
   def default_db(name, type, server)
     project = Project.where(name: 'default').get(:id)
-    DBResource.create(name: name, type: type, project_id: project,
-                      server: server)[:id]
+    # use find or create because create() crashes if a duplicate is found
+    DBResource.find_or_create(name: name, type: type, project_id: project,
+                              server: server)[:id]
   end
 
   # create a node resource if we come across one in the data that isn't defined
   # already. Assign it to the default project.
   def default_node(name, type, cluster)
     project = Project.where(name: 'default').get(:id)
-    NodeResource.create(name: name, type: type, project_id: project,
-                        cluster: cluster)[:id]
+    # use find or create because create() crashes if a duplicate is found
+    NodeResource.find_or_create(name: name, type: type, project_id: project,
+                                cluster: cluster)[:id]
   end
 end
 

--- a/plugins/DBSize/plugin.rb
+++ b/plugins/DBSize/plugin.rb
@@ -19,7 +19,7 @@ class DBSize < BasePlugin
     register
   end
 
-  # rubocop: disable MethodLength, AbcSize
+  # rubocop: disable MethodLength,AbcSize
   def store(db_host)
     # Pull node information from cache as a ruby hash
     db_info = @cache.get(db_host)
@@ -37,8 +37,10 @@ class DBSize < BasePlugin
     # check if resource exists, otherwise create it for the default project
     db_resource = @database[:db_resources].where(name: db_host).get(:id)
 
-    db_resource = default_db(db_host, db_info['type'],
-                             db_info['server']) unless db_resource
+    unless db_resource
+      db_resource = default_db(db_host, db_info['type'],
+                               db_info['server'])
+    end
 
     # Insert data into db_size_measurements table
     @database[@table].insert(

--- a/spec/models/db_spec.rb
+++ b/spec/models/db_spec.rb
@@ -7,8 +7,8 @@ describe 'The DBResource Model and table' do
 
   include Rack::Test::Methods
 
-  it 'initially has one DBResource (the default DBResource)' do
-    expect(DBResource.count).to be(1)
+  it 'initially has zero DBResources' do
+    expect(DBResource.count).to be(0)
   end
 
   it 'has a model name' do

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -7,8 +7,8 @@ describe 'The NodeResource Model and table' do
 
   include Rack::Test::Methods
 
-  it 'initially have only one NodeResource(the defualt)' do
-    expect(NodeResource.count).to be(1)
+  it 'initially have only zero NodeResource' do
+    expect(NodeResource.count).to be(0)
   end
 
   it 'has a model name' do


### PR DESCRIPTION
<!--
  This is a guideline for what a PR should look like.
  Feel free to modify it to fit your specific needs.

  Please list the issue this fixes in the PR
-->
fixes issue #184
did a little clean up from my mistake of using default node/db resources from an older PR

## Changes in this PR.
<!--
  Please include a list of all things this PR will accomplish
  Use the checkbox syntax to show what is done and what is yet to be completed.
  This gives context to the diff.
-->

- [X] removed default node and db resources from app.rb
- [X] used find_or_create in base plugin because create() raises an exeception when it finds a duplicate
- [X] Fix spec 
- [X] Fix rubocop issue in DBSize plugin

## Testing this PR.
<!--
  Please include a list of explicit instructions for testing this PR.
  If the instructions are 'run `make test`' say that,
  If they are more complicated be thorough.
-->

1. Do rake spec
2. See no errors.

### Expected Output.
<!--
  Please insert either a description of what should happen when testing
  your PR or a code-block with terminal output.
-->

```
$ rake spec
[...]
```

@osuosl/devs

